### PR TITLE
Showing analysis result via code actions

### DIFF
--- a/src/main/java/GoblintAnalysis.java
+++ b/src/main/java/GoblintAnalysis.java
@@ -36,6 +36,7 @@ public class GoblintAnalysis implements ToolAnalysis {
 
     public GoblintAnalysis(MagpieServer server) {
         this.magpieServer = server;
+        magpieServer.addCommand("showresult", new ShowResultCommand());
     }
 
     /**

--- a/src/main/java/GoblintAnalysisResult.java
+++ b/src/main/java/GoblintAnalysisResult.java
@@ -2,11 +2,13 @@ import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.util.collections.Pair;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 import magpiebridge.core.AnalysisResult;
 import magpiebridge.core.Kind;
 import magpiebridge.util.SourceCodeReader;
 
+import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
 public class GoblintAnalysisResult implements AnalysisResult {
@@ -97,5 +99,10 @@ public class GoblintAnalysisResult implements AnalysisResult {
         }
         return code;
     }
-    
+
+    @Override
+    public Iterable<Command> command() {
+        Command command = new Command("show result", "showresult", Collections.singletonList(position().getFirstLine()));
+        return Collections.singleton(command);
+    }
 }

--- a/src/main/java/ShowResultCommand.java
+++ b/src/main/java/ShowResultCommand.java
@@ -1,0 +1,16 @@
+import com.google.gson.JsonPrimitive;
+import magpiebridge.core.MagpieServer;
+import magpiebridge.core.WorkspaceCommand;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+public class ShowResultCommand implements WorkspaceCommand  {
+    @Override
+    public void execute(ExecuteCommandParams params, MagpieServer server, LanguageClient client) {
+        JsonPrimitive line = (JsonPrimitive) params.getArguments().get(0);
+        server.forwardMessageToClient(new MessageParams(MessageType.Info, "Showing result for position: " + line));
+    }
+}


### PR DESCRIPTION
As [suggested](https://github.com/MagpieBridge/MagpieBridge/issues/67) by @linghuiluo, we could insert markers to show analysis results via their associated code actions. This idea is worth trying out. It could make things a bit cluttered, but if one only puts them at loop heads, it might be a viable approach. 